### PR TITLE
fix: replaceProjectId should not fail when passed a Buffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export function replaceProjectIdToken(value: any, projectId: string): any {
   }
 
   if (value !== null && typeof value === 'object' &&
+      !(value instanceof Buffer) &&
       typeof value.hasOwnProperty === 'function') {
     for (const opt in value) {
       if (value.hasOwnProperty(opt)) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -95,4 +95,19 @@ describe('projectId placeholder', () => {
       });
     }, /Sorry, we cannot connect/);
   });
+
+  it('should return object containing a buffer as-is', () => {
+    const bufferContainingObject = {
+      prop1: 'A {{projectId}} Z',
+      buf: Buffer.from('test'),
+    };
+
+    const replaced = replaceProjectIdToken(bufferContainingObject, PROJECT_ID);
+    assert.deepStrictEqual(
+        {
+          prop1: `A ${PROJECT_ID} Z`,
+          buf: Buffer.from('test'),
+        },
+        replaced);
+  });
 });


### PR DESCRIPTION
Fixes GCS OOM issue: https://github.com/googleapis/nodejs-storage/issues/390