### PR TITLE
fix: do not replace projectId on stream objects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import {Stream} from 'stream';
+
 /**
  * Copyright 2014 Google Inc. All Rights Reserved.
  *
@@ -30,7 +32,7 @@ export function replaceProjectIdToken(value: any, projectId: string): any {
   }
 
   if (value !== null && typeof value === 'object' &&
-      !(value instanceof Buffer) &&
+      !(value instanceof Buffer) && !(value instanceof Stream) &&
       typeof value.hasOwnProperty === 'function') {
     for (const opt in value) {
       if (value.hasOwnProperty(opt)) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from 'assert';
+import * as stream from 'stream';
 import {replaceProjectIdToken} from '../src';
 
 describe('projectId placeholder', () => {
@@ -109,5 +110,14 @@ describe('projectId placeholder', () => {
           buf: Buffer.from('test'),
         },
         replaced);
+  });
+
+  it('should not inject projectId into stream', () => {
+    // tslint:disable-next-line: no-any
+    const transform = new stream.Transform() as any;
+    transform.prop = 'A {{projectId}} Z';
+
+    const replaced = replaceProjectIdToken(transform, PROJECT_ID);
+    assert.deepEqual(transform.prop, replaced.prop);
   });
 });


### PR DESCRIPTION
https://github.com/googleapis/nodejs-storage/issues/390 points out that OOM happens when `replaceProjectIdToken()` is passed `{ 'Content-Type': 'image/jpeg', body: [DestroyableTransform] }` where the function tries to iterate through the stream's properties.

The stream doesn't contain strings that needs replacing, so let's skip this.