### PR TITLE
fix: Pin @types/sinon to last compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "mocha": "^5.2.0",
     "nyc": "^13.0.0",
     "source-map-support": "^0.5.6",
-    "typescript": "^3.0.0"
+    "typescript": "^3.0.0",
+    "@types/sinon": "5.0.5"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
@types/sinon had an update over the weekend which broke many of our tests. The *real* fix is [something like this](https://github.com/googleapis/nodejs-spanner/pull/441/files), but for now, this should fix our broken CI and give us some breathing room.